### PR TITLE
Fix inChildOf and some property domains

### DIFF
--- a/sbol-owl3-gen/App.py
+++ b/sbol-owl3-gen/App.py
@@ -254,7 +254,7 @@ with sbol3:
     SequenceFeature.is_a.append(hasLocation.some(Location))
     
     #-----ComponentReference properties-----
-    class inChildOf(SubComponent >> Component , FunctionalProperty):
+    class inChildOf(ComponentReference >> SubComponent, FunctionalProperty):
         label = "inChildOf"  
     ComponentReference.is_a.append(inChildOf.some(Component))
           

--- a/sbol-owl3-gen/App.py
+++ b/sbol-owl3-gen/App.py
@@ -192,7 +192,7 @@ with sbol3:
     #-----Component properties-----
     class type(ObjectProperty):
         label = "type"
-        domain = [Component, LocalSubComponent, ExternallyDefined, Interaction]
+        domain = [Or([Component, LocalSubComponent, ExternallyDefined, Interaction])]
     Component.is_a.append(type.some(Thing))
     LocalSubComponent.is_a.append(type.some(Thing))
     ExternallyDefined.is_a.append(type.some(Thing))
@@ -200,19 +200,19 @@ with sbol3:
     
     class role(ObjectProperty):
         label = "role"
-        domain = [Component, Feature, Participation]
+        domain = [Or([Component, Feature, Participation])]
     Participation.is_a.append(role.some(Thing))
        
     class hasSequence(ObjectProperty):
         label = "hasSequence"
-        domain = [Component, Location]
+        domain = [Or([Component, Location])]
         range= [Sequence]
     Location.is_a.append(hasSequence.some(Sequence))
     Location.is_a.append(hasSequence.max(1,Sequence))
         
     class hasFeature(ObjectProperty):
         label = "hasFeature"
-        domain = [Component, ComponentReference]
+        domain = [Or([Component, ComponentReference])]
         range= [Feature]
     ComponentReference.is_a.append(hasFeature.some(Feature))
     ComponentReference.is_a.append(hasFeature.max(1,Feature))
@@ -232,7 +232,7 @@ with sbol3:
     #-----Feature properties-----
     class orientation(ObjectProperty, FunctionalProperty):
         label = "orientation"
-        domain = [Feature, Location]
+        domain = [Or([Feature, Location])]
         range = [Orientation]
       
     #-----SubComponent properties-----
@@ -249,7 +249,7 @@ with sbol3:
     
     class hasLocation(ObjectProperty):
         label = "hasLocation"
-        domain = [SubComponent, LocalSubComponent, SequenceFeature] 
+        domain = [Or([SubComponent, LocalSubComponent, SequenceFeature])]
         range = [Location]
     SequenceFeature.is_a.append(hasLocation.some(Location))
     
@@ -367,7 +367,7 @@ with sbol3:
     #-----Model properties-----
     class source(ObjectProperty, FunctionalProperty):
         label = "source"  
-        domain = [Model, Attachment]
+        domain = [Or([Model, Attachment])]
     Model.is_a.append(source.some(Thing))
     Attachment.is_a.append(source.some(Thing))
     

--- a/sbolowl3.rdf
+++ b/sbolowl3.rdf
@@ -27,30 +27,54 @@
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#type">
-  <rdfs:domain rdf:resource="#Interaction"/>
-  <rdfs:domain rdf:resource="#ExternallyDefined"/>
-  <rdfs:domain rdf:resource="#Component"/>
-  <rdfs:domain rdf:resource="#LocalSubComponent"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#LocalSubComponent"/>
+        <rdf:Description rdf:about="#ExternallyDefined"/>
+        <rdf:Description rdf:about="#Interaction"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">type</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#role">
-  <rdfs:domain rdf:resource="#Feature"/>
-  <rdfs:domain rdf:resource="#Component"/>
-  <rdfs:domain rdf:resource="#Participation"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#Feature"/>
+        <rdf:Description rdf:about="#Participation"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">role</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#hasSequence">
-  <rdfs:domain rdf:resource="#Location"/>
-  <rdfs:domain rdf:resource="#Component"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#Location"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Sequence"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasSequence</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#hasFeature">
-  <rdfs:domain rdf:resource="#ComponentReference"/>
-  <rdfs:domain rdf:resource="#Component"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#ComponentReference"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Feature"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasFeature</rdfs:label>
 </owl:ObjectProperty>
@@ -82,8 +106,14 @@
 
 <owl:ObjectProperty rdf:about="#orientation">
   <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-  <rdfs:domain rdf:resource="#Feature"/>
-  <rdfs:domain rdf:resource="#Location"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Feature"/>
+        <rdf:Description rdf:about="#Location"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Orientation"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">orientation</rdfs:label>
 </owl:ObjectProperty>
@@ -108,17 +138,23 @@
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#hasLocation">
-  <rdfs:domain rdf:resource="#SequenceFeature"/>
-  <rdfs:domain rdf:resource="#SubComponent"/>
-  <rdfs:domain rdf:resource="#LocalSubComponent"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#SubComponent"/>
+        <rdf:Description rdf:about="#LocalSubComponent"/>
+        <rdf:Description rdf:about="#SequenceFeature"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Location"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasLocation</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#inChildOf">
   <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-  <rdfs:domain rdf:resource="#SubComponent"/>
-  <rdfs:range rdf:resource="#Component"/>
+  <rdfs:domain rdf:resource="#ComponentReference"/>
+  <rdfs:range rdf:resource="#SubComponent"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inChildOf</rdfs:label>
 </owl:ObjectProperty>
 
@@ -253,8 +289,14 @@
 
 <owl:ObjectProperty rdf:about="#source">
   <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-  <rdfs:domain rdf:resource="#Attachment"/>
-  <rdfs:domain rdf:resource="#Model"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Model"/>
+        <rdf:Description rdf:about="#Attachment"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">source</rdfs:label>
 </owl:ObjectProperty>
 

--- a/sbolowl3.txt
+++ b/sbolowl3.txt
@@ -27,30 +27,54 @@
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#type">
-  <rdfs:domain rdf:resource="#Interaction"/>
-  <rdfs:domain rdf:resource="#ExternallyDefined"/>
-  <rdfs:domain rdf:resource="#Component"/>
-  <rdfs:domain rdf:resource="#LocalSubComponent"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#LocalSubComponent"/>
+        <rdf:Description rdf:about="#ExternallyDefined"/>
+        <rdf:Description rdf:about="#Interaction"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">type</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#role">
-  <rdfs:domain rdf:resource="#Feature"/>
-  <rdfs:domain rdf:resource="#Component"/>
-  <rdfs:domain rdf:resource="#Participation"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#Feature"/>
+        <rdf:Description rdf:about="#Participation"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">role</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#hasSequence">
-  <rdfs:domain rdf:resource="#Location"/>
-  <rdfs:domain rdf:resource="#Component"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#Location"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Sequence"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasSequence</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#hasFeature">
-  <rdfs:domain rdf:resource="#ComponentReference"/>
-  <rdfs:domain rdf:resource="#Component"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Component"/>
+        <rdf:Description rdf:about="#ComponentReference"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Feature"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasFeature</rdfs:label>
 </owl:ObjectProperty>
@@ -82,8 +106,14 @@
 
 <owl:ObjectProperty rdf:about="#orientation">
   <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-  <rdfs:domain rdf:resource="#Feature"/>
-  <rdfs:domain rdf:resource="#Location"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Feature"/>
+        <rdf:Description rdf:about="#Location"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Orientation"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">orientation</rdfs:label>
 </owl:ObjectProperty>
@@ -108,17 +138,23 @@
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#hasLocation">
-  <rdfs:domain rdf:resource="#SequenceFeature"/>
-  <rdfs:domain rdf:resource="#SubComponent"/>
-  <rdfs:domain rdf:resource="#LocalSubComponent"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#SubComponent"/>
+        <rdf:Description rdf:about="#LocalSubComponent"/>
+        <rdf:Description rdf:about="#SequenceFeature"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:range rdf:resource="#Location"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasLocation</rdfs:label>
 </owl:ObjectProperty>
 
 <owl:ObjectProperty rdf:about="#inChildOf">
   <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-  <rdfs:domain rdf:resource="#SubComponent"/>
-  <rdfs:range rdf:resource="#Component"/>
+  <rdfs:domain rdf:resource="#ComponentReference"/>
+  <rdfs:range rdf:resource="#SubComponent"/>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inChildOf</rdfs:label>
 </owl:ObjectProperty>
 
@@ -253,8 +289,14 @@
 
 <owl:ObjectProperty rdf:about="#source">
   <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-  <rdfs:domain rdf:resource="#Attachment"/>
-  <rdfs:domain rdf:resource="#Model"/>
+  <rdfs:domain>
+    <owl:Class>
+      <owl:unionOf rdf:parseType="Collection">
+        <rdf:Description rdf:about="#Model"/>
+        <rdf:Description rdf:about="#Attachment"/>
+      </owl:unionOf>
+    </owl:Class>
+  </rdfs:domain>
   <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">source</rdfs:label>
 </owl:ObjectProperty>
 


### PR DESCRIPTION
1. Fix domain and range of `inChildOf` - `inChildOf` is a property of ComponentReference whose range is
SubComponent.
2. Fix parent class conjunctions - A number of SBOL3 properties can appear on different classes. The ontology should specify that these properties can appear on one OR the other of the classes rather than requiring that they appear only on objects that have ALL of the named classes. By default the domains are conjunctions, specifying AND rather than OR. Explicitly use an OR on the domains.
